### PR TITLE
Biblios items service

### DIFF
--- a/lib/models/biblio_item.dart
+++ b/lib/models/biblio_item.dart
@@ -1,0 +1,52 @@
+//import 'package:catbiblio_app/models/item_location.dart';
+
+class BiblioItem {
+  String itemType; // Currently only displaying the id: item_types endpoint
+  String holdingLibrary; // Currently only displaying the id: libraries endpoint
+  String collection; // Currently only displaying the id: CCODE authorised value
+  String callNumber;
+  String callNumberSort;
+  String copyNumber;
+  int notForLoanStatus;
+  String? checkedOutDate;
+  bool borrowedStatus; // Not in json, calculated based on checkedOutDate
+  /*
+  ItemLocation
+  location; // Used for geographical location - not in json: to be calculated later
+  */
+
+  BiblioItem({
+    required this.itemType,
+    required this.holdingLibrary,
+    required this.collection,
+    required this.callNumber,
+    required this.callNumberSort,
+    required this.copyNumber,
+    required this.notForLoanStatus,
+    this.checkedOutDate,
+    this.borrowedStatus = false,
+    //ItemLocation? location,
+  });
+  /*: location =
+           location ??
+           ItemLocation(floor: '', room: '', shelf: '', shelfSide: '');*/
+
+  factory BiblioItem.fromJson(Map<String, dynamic> json) {
+    return BiblioItem(
+      itemType: json['item_type_id'],
+      holdingLibrary: json['holding_library_id'],
+      collection: json['collection_code'],
+      callNumber: json['callnumber'],
+      callNumberSort: json['call_number_sort'],
+      copyNumber: json['copy_number'],
+      notForLoanStatus: json['not_for_loan_status'],
+      checkedOutDate: json['checked_out_date'] as String?,
+      borrowedStatus: json['checked_out_date'] != null,
+    );
+  }
+
+  @override
+  String toString() {
+    return 'BiblioItem(itemType: $itemType, holdingLibrary: $holdingLibrary, collection: $collection, callNumber: $callNumber, callNumberSort: $callNumberSort, copyNumber: $copyNumber, notForLoanStatus: $notForLoanStatus, checkedOutDate: $checkedOutDate, borrowedStatus: $borrowedStatus)';
+  }
+}

--- a/lib/models/item_location.dart
+++ b/lib/models/item_location.dart
@@ -1,0 +1,13 @@
+class ItemLocation {
+  String floor; // -1, 0, 1, 2, 3
+  String room; // Sala 1, Sala 2, etc.
+  String shelf;
+  String shelfSide; // A or B
+
+  ItemLocation({
+    required this.floor,
+    required this.room,
+    required this.shelf,
+    required this.shelfSide,
+  });
+}

--- a/lib/services/rest/biblios_items.dart
+++ b/lib/services/rest/biblios_items.dart
@@ -23,6 +23,11 @@ class BibliosItemsService {
   ///
   /// Returns an empty list if no items are found or in case of an error
   static Future<List<BiblioItem>> getBiblioItems(int biblioNumber) async {
+    if (biblioNumber <= 0) {
+      debugPrint('Invalid biblionumber: $biblioNumber');
+      return [];
+    }
+
     try {
       final response = await _dio.get(
         '/biblios_items',

--- a/lib/services/rest/biblios_items.dart
+++ b/lib/services/rest/biblios_items.dart
@@ -17,7 +17,7 @@ class BibliosItemsService {
     ),
   );
 
-  /// Fetches de list of items for a given title by its biblionumber from a Koha-based service
+  /// Fetches the list of items for a given title by its biblionumber from a Koha-based service
   ///
   /// Returns a [BiblioItem] list containing the items for the specified [biblioNumber].
   ///

--- a/lib/services/rest/biblios_items.dart
+++ b/lib/services/rest/biblios_items.dart
@@ -1,0 +1,71 @@
+import 'package:dio/dio.dart';
+import 'dart:convert';
+import 'package:catbiblio_app/models/biblio_item.dart';
+import 'package:flutter/material.dart';
+
+class BibliosItemsService {
+  static final Dio _dio = Dio(
+    BaseOptions(
+      baseUrl: 'http://148.226.6.25/cgi-bin/koha/svc', // Move to .env
+      responseType: ResponseType.plain,
+      connectTimeout: const Duration(seconds: 10),
+      receiveTimeout: const Duration(seconds: 30),
+      headers: {
+        'Accept': 'application/json;encoding=UTF-8',
+        'x-api-key': '12345', // Move to .env
+      },
+    ),
+  );
+
+  /// Fetches de list of items for a given title by its biblionumber from a Koha-based service
+  ///
+  /// Returns a [BiblioItem] list containing the items for the specified [biblioNumber].
+  ///
+  /// Returns an empty list if no items are found or in case of an error
+  static Future<List<BiblioItem>> getBiblioItems(int biblioNumber) async {
+    try {
+      final response = await _dio.get(
+        '/biblios_items',
+        queryParameters: {'biblio_number': biblioNumber},
+      );
+
+      debugPrint('Request URL: ${response.realUri}');
+
+      final List<dynamic> itemsJson = json.decode(response.data);
+
+      return itemsJson
+          .map((json) => BiblioItem.fromJson(json as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      // Log the error for debugging
+      debugPrint('DioException in getBiblioItems: ${e.message}');
+      debugPrint('Response data: ${e.response?.data}');
+      debugPrint('Status code: ${e.response?.statusCode}');
+
+      // Handle specific error types
+      switch (e.type) {
+        case DioExceptionType.connectionTimeout:
+        case DioExceptionType.receiveTimeout:
+          debugPrint('Timeout error: Check network connection');
+          break;
+        case DioExceptionType.badResponse:
+          debugPrint('Server error: ${e.response?.statusCode}');
+          break;
+        case DioExceptionType.cancel:
+          debugPrint('Request cancelled');
+          break;
+        case DioExceptionType.unknown:
+          debugPrint('Unknown error: ${e.message}');
+          break;
+        default:
+          debugPrint('Dio error: $e');
+      }
+
+      return [];
+    } catch (e) {
+      // Handle JSON parsing or other errors
+      debugPrint('Unexpected error in getBiblioItems: $e');
+      return [];
+    }
+  }
+}

--- a/lib/services/rest/libraries.dart
+++ b/lib/services/rest/libraries.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 class LibrariesService {
   static final Dio _dio = Dio(
     BaseOptions(
-      baseUrl: 'http://148.226.6.25',
+      baseUrl: 'http://148.226.6.25/cgi-bin/koha/svc',
       responseType: ResponseType.plain,
       connectTimeout: const Duration(seconds: 10),
       receiveTimeout: const Duration(seconds: 30),
@@ -18,7 +18,7 @@ class LibrariesService {
   /// Example: http://{{baseUrl}}/cgi-bin/koha/svc/libraries
   static Future<List<Library>> getLibraries() async {
     try {
-      final response = await _dio.get('/cgi-bin/koha/svc/libraries');
+      final response = await _dio.get('/libraries');
 
       final List<dynamic> librariesJson = json.decode(response.data);
 

--- a/lib/services/svc/search.dart
+++ b/lib/services/svc/search.dart
@@ -30,7 +30,7 @@ class ApiException extends SruException {
 class SruService {
   static final Dio _dio = Dio(
     BaseOptions(
-      baseUrl: 'http://148.226.6.25',
+      baseUrl: 'http://148.226.6.25/cgi-bin/koha/svc',
       responseType: ResponseType.plain,
       connectTimeout: const Duration(seconds: 10),
       receiveTimeout: const Duration(seconds: 30),
@@ -65,7 +65,7 @@ class SruService {
 
     try {
       final response = await _dio.get(
-        '/cgi-bin/koha/svc/app_search',
+        '/app_search',
         queryParameters: queryParameters,
       );
 

--- a/lib/test/biblios_items_test.dart
+++ b/lib/test/biblios_items_test.dart
@@ -1,0 +1,27 @@
+import 'package:test/test.dart';
+import 'package:flutter/foundation.dart';
+import 'package:catbiblio_app/models/biblio_item.dart';
+import 'package:catbiblio_app/services/rest/biblios_items.dart';
+
+void main() {
+  group('BibliosItemsService requests', () {
+    test('getBiblioItems returns a list of biblio items', () async {
+      const testBiblionumber = 383385;
+      final items = await BibliosItemsService.getBiblioItems(testBiblionumber);
+
+      debugPrint('Fetched ${items.length} biblio items');
+      debugPrint(
+        'First item: ${items.isNotEmpty ? items.first : 'No items found'}',
+      );
+      debugPrint(
+        'Last item: ${items.isNotEmpty ? items.last : 'No items found'}',
+      );
+
+      expect(items, isA<List<BiblioItem>>());
+      expect(items.isNotEmpty, isTrue);
+      expect(items.length, greaterThan(0));
+    });
+
+    // TODO: Add more test cases
+  });
+}

--- a/lib/test/biblios_items_test.dart
+++ b/lib/test/biblios_items_test.dart
@@ -22,6 +22,46 @@ void main() {
       expect(items.length, greaterThan(0));
     });
 
-    // TODO: Add more test cases
+    test('getBiblioItems handles invalid biblionumber', () async {
+      const invalidBiblionumber = -1;
+      final items = await BibliosItemsService.getBiblioItems(
+        invalidBiblionumber,
+      );
+
+      debugPrint(
+        'Fetched ${items.length} biblio items for invalid biblionumber',
+      );
+
+      expect(items, isA<List<BiblioItem>>());
+      expect(items.isEmpty, isTrue);
+    });
+
+    test('getBiblioItems handles non-existent biblionumber', () async {
+      const nonExistentBiblionumber = 999999999;
+      final items = await BibliosItemsService.getBiblioItems(
+        nonExistentBiblionumber,
+      );
+
+      debugPrint(
+        'Fetched ${items.length} biblio items for non-existent biblionumber',
+      );
+
+      expect(items, isA<List<BiblioItem>>());
+      expect(items.isEmpty, isTrue);
+    });
+
+    test('getBiblioItems handles string biblionumber', () async {
+      const invalidBiblionumber = "383385";
+      final items = await BibliosItemsService.getBiblioItems(
+        int.tryParse(invalidBiblionumber) ?? -1,
+      );
+      debugPrint(
+        'Fetched ${items.length} biblio items for string biblionumber',
+      );
+
+      expect(items, isA<List<BiblioItem>>());
+      expect(items.isNotEmpty, isTrue);
+      expect(items.length, greaterThan(0));
+    });
   });
 }


### PR DESCRIPTION
This pull request introduces a new model and service for handling bibliographic items, along with corresponding tests. It also standardizes the base URLs and endpoints for Koha-based services across the codebase for consistency and correctness. The most important changes are summarized below:

### New Features

* Added a `BiblioItem` model in `biblio_item.dart` to represent bibliographic item data, including parsing from JSON and a computed `borrowedStatus` field.
* Created an `ItemLocation` model in `item_location.dart` to represent physical item location details, to be integrated in the future.
* Implemented the `BibliosItemsService` in `biblios_items.dart` for fetching items by biblionumber, with error handling and JSON parsing.
* Added comprehensive tests for `BibliosItemsService` in `biblios_items_test.dart`, covering valid, invalid, non-existent, and string biblionumber scenarios.

### Service Endpoint and URL Standardization

* Updated base URLs in `libraries.dart` and `search.dart` to use `/cgi-bin/koha/svc` for consistency with the Koha service structure, and adjusted endpoints accordingly (e.g., `/libraries`, `/app_search`). [[1]](diffhunk://#diff-46a83b3f0fc5ccd69674bc68881c539df4843b39429c39921be2bdaf0358a98bL9-R9) [[2]](diffhunk://#diff-46a83b3f0fc5ccd69674bc68881c539df4843b39429c39921be2bdaf0358a98bL21-R21) [[3]](diffhunk://#diff-3032bd5538cf4c9c1b92af97046e650fd338c46c550942300d9a64963bc6e4edL33-R33) [[4]](diffhunk://#diff-3032bd5538cf4c9c1b92af97046e650fd338c46c550942300d9a64963bc6e4edL68-R68)