### PR TITLE
Update biblios items

### DIFF
--- a/lib/models/biblio_item.dart
+++ b/lib/models/biblio_item.dart
@@ -1,6 +1,10 @@
 //import 'package:catbiblio_app/models/item_location.dart';
 
 class BiblioItem {
+  static const int STATUS_AVAILABLE = 0;
+  static const int STATUS_BORROWED = 1;
+  static const int STATUS_NOT_FOR_LOAN = 2;
+
   String itemTypeId;
   String itemType;
   String holdingLibraryId;
@@ -13,6 +17,8 @@ class BiblioItem {
   int notForLoanStatus;
   String? checkedOutDate;
   bool borrowedStatus; // Not in json, calculated based on checkedOutDate
+  int
+  overAllStatus; // Not in json, to be calculated later 0 = available, 1 = borrowed, 2 = not for loan
   /*
   ItemLocation
   location; // Used for geographical location - not in json: to be calculated later
@@ -32,12 +38,16 @@ class BiblioItem {
     this.checkedOutDate,
     this.borrowedStatus = false,
     //ItemLocation? location,
-  });
+  }) : overAllStatus = notForLoanStatus != STATUS_AVAILABLE
+           ? STATUS_NOT_FOR_LOAN
+           : (checkedOutDate != null ? STATUS_BORROWED : STATUS_AVAILABLE);
   /*: location =
            location ??
            ItemLocation(floor: '', room: '', shelf: '', shelfSide: '');*/
 
   factory BiblioItem.fromJson(Map<String, dynamic> json) {
+    final checkedOutDate = json['checked_out_date'] as String?;
+    final notForLoanStatus = json['not_for_loan_status'];
     return BiblioItem(
       itemTypeId: json['item_type_id'],
       itemType: json['item_type'],
@@ -48,14 +58,14 @@ class BiblioItem {
       callNumber: json['callnumber'],
       callNumberSort: json['call_number_sort'],
       copyNumber: json['copy_number'],
-      notForLoanStatus: json['not_for_loan_status'],
-      checkedOutDate: json['checked_out_date'] as String?,
-      borrowedStatus: json['checked_out_date'] != null,
+      notForLoanStatus: notForLoanStatus,
+      checkedOutDate: checkedOutDate,
+      borrowedStatus: checkedOutDate != null,
     );
   }
 
   @override
   String toString() {
-    return 'BiblioItem(itemTypeId: $itemTypeId, itemType: $itemType, holdingLibraryId: $holdingLibraryId, holdingLibrary: $holdingLibrary, collectionCode: $collectionCode, collection: $collection, callNumber: $callNumber, callNumberSort: $callNumberSort, copyNumber: $copyNumber, notForLoanStatus: $notForLoanStatus, checkedOutDate: $checkedOutDate, borrowedStatus: $borrowedStatus)';
+    return 'BiblioItem(itemTypeId: $itemTypeId, itemType: $itemType, holdingLibraryId: $holdingLibraryId, holdingLibrary: $holdingLibrary, collectionCode: $collectionCode, collection: $collection, callNumber: $callNumber, callNumberSort: $callNumberSort, copyNumber: $copyNumber, notForLoanStatus: $notForLoanStatus, checkedOutDate: $checkedOutDate, borrowedStatus: $borrowedStatus, overAllStatus: $overAllStatus)';
   }
 }

--- a/lib/models/biblio_item.dart
+++ b/lib/models/biblio_item.dart
@@ -1,9 +1,12 @@
 //import 'package:catbiblio_app/models/item_location.dart';
 
 class BiblioItem {
-  String itemType; // Currently only displaying the id: item_types endpoint
-  String holdingLibrary; // Currently only displaying the id: libraries endpoint
-  String collection; // Currently only displaying the id: CCODE authorised value
+  String itemTypeId;
+  String itemType;
+  String holdingLibraryId;
+  String holdingLibrary;
+  String collectionCode;
+  String collection;
   String callNumber;
   String callNumberSort;
   String copyNumber;
@@ -16,8 +19,11 @@ class BiblioItem {
   */
 
   BiblioItem({
+    required this.itemTypeId,
     required this.itemType,
+    required this.holdingLibraryId,
     required this.holdingLibrary,
+    required this.collectionCode,
     required this.collection,
     required this.callNumber,
     required this.callNumberSort,
@@ -33,9 +39,12 @@ class BiblioItem {
 
   factory BiblioItem.fromJson(Map<String, dynamic> json) {
     return BiblioItem(
-      itemType: json['item_type_id'],
-      holdingLibrary: json['holding_library_id'],
-      collection: json['collection_code'],
+      itemTypeId: json['item_type_id'],
+      itemType: json['item_type'],
+      holdingLibraryId: json['holding_library_id'],
+      holdingLibrary: json['holding_library'],
+      collectionCode: json['collection_code'],
+      collection: json['collection'],
       callNumber: json['callnumber'],
       callNumberSort: json['call_number_sort'],
       copyNumber: json['copy_number'],
@@ -47,6 +56,6 @@ class BiblioItem {
 
   @override
   String toString() {
-    return 'BiblioItem(itemType: $itemType, holdingLibrary: $holdingLibrary, collection: $collection, callNumber: $callNumber, callNumberSort: $callNumberSort, copyNumber: $copyNumber, notForLoanStatus: $notForLoanStatus, checkedOutDate: $checkedOutDate, borrowedStatus: $borrowedStatus)';
+    return 'BiblioItem(itemTypeId: $itemTypeId, itemType: $itemType, holdingLibraryId: $holdingLibraryId, holdingLibrary: $holdingLibrary, collectionCode: $collectionCode, collection: $collection, callNumber: $callNumber, callNumberSort: $callNumberSort, copyNumber: $copyNumber, notForLoanStatus: $notForLoanStatus, checkedOutDate: $checkedOutDate, borrowedStatus: $borrowedStatus)';
   }
 }

--- a/lib/test/biblios_items_test.dart
+++ b/lib/test/biblios_items_test.dart
@@ -22,6 +22,25 @@ void main() {
       expect(items.length, greaterThan(0));
     });
 
+    test(
+      'getBiblioItems returns a list of biblio items for a not for loan item',
+      () async {
+        const testBiblionumber = 383061;
+        final items = await BibliosItemsService.getBiblioItems(
+          testBiblionumber,
+        );
+
+        debugPrint('Fetched ${items.length} biblio items');
+        debugPrint(
+          'First item: ${items.isNotEmpty ? items.first : 'No items found'}',
+        );
+
+        expect(items, isA<List<BiblioItem>>());
+        expect(items.isNotEmpty, isTrue);
+        expect(items.length, greaterThan(0));
+      },
+    );
+
     test('getBiblioItems handles invalid biblionumber', () async {
       const invalidBiblionumber = -1;
       final items = await BibliosItemsService.getBiblioItems(


### PR DESCRIPTION
This pull request enhances the `BiblioItem` model to better represent item statuses and IDs, and adds a new test case for "not for loan" items. The changes improve data clarity and reliability when handling bibliographic items.

### Model enhancements

* Added new fields to `BiblioItem` for `itemTypeId`, `holdingLibraryId`, and `collectionCode`, and updated the constructor and `fromJson` factory to populate them. This makes the model more descriptive and aligns it with the backend data. [[1]](diffhunk://#diff-5668c3ba61ff119b6f0e82701d6d7878d4260c8258e11006a3bc704ea265535cL4-R32) [[2]](diffhunk://#diff-5668c3ba61ff119b6f0e82701d6d7878d4260c8258e11006a3bc704ea265535cL29-R69)
* Introduced static constants for item statuses (`STATUS_AVAILABLE`, `STATUS_BORROWED`, `STATUS_NOT_FOR_LOAN`) and new `overAllStatus` logic, which is calculated based on loan status and checkout date. [[1]](diffhunk://#diff-5668c3ba61ff119b6f0e82701d6d7878d4260c8258e11006a3bc704ea265535cL4-R32) [[2]](diffhunk://#diff-5668c3ba61ff119b6f0e82701d6d7878d4260c8258e11006a3bc704ea265535cL29-R69)